### PR TITLE
Fork/master

### DIFF
--- a/dp832.cpp
+++ b/dp832.cpp
@@ -40,6 +40,8 @@ int dp830::GetState(int channel){
 
 int dp830::On(int channel) {
     char buf[40];
+    snprintf(buf,sizeof(buf),":SOUR%d:CURR:PROT:CLEAR",channel);
+    write_(buf);
     snprintf(buf,sizeof(buf),":OUTP:STAT CH%d,ON",channel);
     return write_(buf);
 }
@@ -76,6 +78,30 @@ int dp830::SetVoltage(int channel, double limit){
 }
 int dp830::SetCurrent(int channel, double limit){
     return SetLimit_(channel,"CURR",limit);
+}
+
+int dp830::SetOCP(int channel, double limit) {
+    char buf[60];
+    snprintf(buf,sizeof(buf),":SOUR%d:CURR:PROT:STAT ON",channel);
+    write_(buf);
+    snprintf(buf,sizeof(buf),":SOUR%d:CURR:PROT %6.3f",channel,limit);
+    return write_(buf);
+}
+
+double dp830::GetOCP(int channel) {
+    char buf[40];
+    snprintf(buf,sizeof(buf),":SOUR%d:CURR:PROT?",channel);
+    write_(buf);
+    read_(buf,sizeof(buf));
+    return std::stod(buf,NULL);
+}
+
+int dp830::GetOCPTripped(int channel) {
+    char buf[40];
+    snprintf(buf,sizeof(buf),":SOUR%d:CURR:PROT:TRIP?",channel);
+    write_(buf);
+    read_(buf,sizeof(buf));
+    return (strcmp(buf,"YES")==0)?1:0;
 }
 
 double dp830::GetSetPoint_(int channel, const char *tag) {

--- a/dp832.h
+++ b/dp832.h
@@ -19,10 +19,14 @@ public:
     void Reset() { write_("*RST"); };
 
     int SetCurrent(int channel, double limit);
+    int SetOCP(int channel, double limit);
     int SetVoltage(int channel, double limit);
+    double GetOCP(int channel);
     double GetCurrentSetPoint(int channel);
     double GetVoltageSetPoint(int channel);
 
+
+    int GetOCPTripped(int channel);
     int Bounce(int channel, double delay);
 
     double MeasureVoltage(int channel);

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include "dp832.h"
 #include <string>
+#include <chrono>
 
 /* psutil - utility for controlling Rigol dp8xx series power supplies
 
@@ -38,6 +39,8 @@
 
 const std::string kValidArgs = "c:v:i:s:b:d:xmw:";
 const std::string kDefaultUSBDevicePath = "/dev/usbtmc1";
+
+using namespace std::chrono;
 
 // Finds and returns the device path argument from the argument list.
 // Returns kDefaultUSBDevicePath if none is provided.
@@ -95,6 +98,7 @@ int main (int argc, char** argv) {
                    fprintf(stderr, "Channel must be in range 1..3\n");
                    return -1;
                 }
+                break;
             case 'v':
                 voltage = std::stod(optarg);
                 psu.SetVoltage(channel,voltage);
@@ -118,7 +122,8 @@ int main (int argc, char** argv) {
                 break;
             case 'm':
                 if (extra) {
-                  printf("c=%d,s=%d,vs=%0.03f,is=%0.03f,v=%0.03f,i=%0.03f,p=%0.03f\n", 
+                  printf("t=%lu,c=%d,s=%d,vs=%0.03f,is=%0.03f,v=%0.03f,i=%0.03f,p=%0.03f\n", 
+                    (duration_cast<milliseconds>(system_clock::now().time_since_epoch())).count(),
                     channel,
                     psu.GetState(channel),
                     psu.GetVoltageSetPoint(channel),
@@ -127,14 +132,14 @@ int main (int argc, char** argv) {
                     psu.MeasureCurrent(channel),
                     psu.MeasurePower(channel));
                 } else { 
-                    printf("Can't use 'm' in legacy mode, add -x flag\n");
+                    fprintf(stderr, "Can't use -m in legacy mode, add -x flag\n");
                 }
                 break;
             case 'w': // ms delay
                 if (extra) {
                     usleep(1000*std::stod(optarg));
                 } else { 
-                    printf("Can't use 'W' in legacy mode, add -x flag\n");
+                    fprintf(stderr, "Can't use -w in legacy mode, add -x flag\n");
                 }
                 break;
             default:

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,8 @@
 
     i - Sets the current setpoint
 
+    t - Sets the overcurrent trip point
+
     s - Sets the state of the output (0-off, not 0-on)
 
     b - Bounce the channel.  Parameter is the off period in seconds.  Will set
@@ -39,7 +41,7 @@
 
 */
 
-const std::string kValidArgs = "c:v:i:s:b:d:xmw:r:";
+const std::string kValidArgs = "c:v:i:s:b:d:xmw:r:t:";
 const std::string kDefaultUSBDevicePath = "/dev/usbtmc1";
 
 using namespace std::chrono;
@@ -111,6 +113,10 @@ int main (int argc, char** argv) {
                 psu.SetCurrent(channel,current);
                 setcurrent=true;
                 break;
+            case 't':
+                current = std::stod(optarg);
+                psu.SetOCP(channel,current);
+                break;
             case 's':
                 state = !(atoi(optarg) == 0);
                 if (state)
@@ -133,15 +139,17 @@ int main (int argc, char** argv) {
                   }
                   for (int i = 0; i < reps; i++) {
                     auto now = (duration_cast<milliseconds>(system_clock::now().time_since_epoch())).count();
-                    printf("t=%lu,c=%d,s=%d,vs=%0.03f,is=%0.03f,v=%0.03f,i=%0.03f,p=%0.03f\n", 
+                    printf("t=%lu,c=%d,s=%d,vs=%0.03f,is=%0.03f,ocp=%0.03f,v=%0.03f,i=%0.03f,p=%0.03f,tr=%d\n", 
                       now,
                       channel,
                       psu.GetState(channel),
                       psu.GetVoltageSetPoint(channel),
                       psu.GetCurrentSetPoint(channel),
+                      psu.GetOCP(channel),
                       psu.MeasureVoltage(channel),
                       psu.MeasureCurrent(channel),
-                      psu.MeasurePower(channel));
+                      psu.MeasurePower(channel),
+                      psu.GetOCPTripped(channel));
                     auto delta = (duration_cast<milliseconds>(system_clock::now().time_since_epoch())).count() - now;
                     if ((tt > delta)) {
                       usleep(1000*(tt-delta));


### PR DESCRIPTION
This simple set of changes allows more flexibility for automation, adding a -x (extra mode) flag that enables -m (measure) and -w (wait) actions in the sequence, so you can set / wait / measure / set / wait / measure etc and the results will be inline with timestamps whereever the -m flag is given.
Also fixed a bug, a break was missing in case 'c'.