### PR TITLE
set self.fd buffering=1 to ensure select line buffering

### DIFF
--- a/dp832.py
+++ b/dp832.py
@@ -21,7 +21,7 @@ class dp832:
         self.connected = False
     else:
       try:
-        self.fd = open(fname,"w+")
+        self.fd = open(fname,"w+", buffering=1)
         self.connected = True
       except IOError as e:
         self.fd = None


### PR DESCRIPTION
Based on python2 and python3 documents,  if buffering is omitted, the system default is used. In my two linux machine, after `write` command, python2 will not buffer, but python3 does buffer the sent command. So I set `self.fd` buffering 1 to ensure line buffering. I think it will be more compatible to set it in explicit. 